### PR TITLE
Moved user exists error to email field on Signup page

### DIFF
--- a/backend/src/controllers/auth.controller.js
+++ b/backend/src/controllers/auth.controller.js
@@ -11,7 +11,7 @@ const register = async (req, res) => {
   try {
     const { username, email, password } = req.body;
     const existingUser = await User.findOne({ where: { email } });
-    if (existingUser) return res.status(400).json({ error: "User already exists" });
+    if (existingUser) return res.status(400).json({ error: "Email already exists" });
 
     const hashedPassword = await bcrypt.hash(password, 10);
     const newUser = await User.create({ username, email, password: hashedPassword });

--- a/frontend/src/scenes/login/CreateAccountPage.jsx
+++ b/frontend/src/scenes/login/CreateAccountPage.jsx
@@ -55,8 +55,8 @@ function CreateAccountPage() {
       navigate('/');
     } catch (error) {
       if (error.response && error.response.data) {
-        if (error.response.data.error === 'User already exists') {
-          setError('User already exists');
+        if (error.response.data.error === 'Email already exists') {
+          setError('Email already exists');
         } else {
           setError('An error occurred. Please try again.');
         }
@@ -82,7 +82,6 @@ function CreateAccountPage() {
           onChange={handleInputChange}
           placeholder="Enter your username"
         />
-        {error && <div className="error-message">{error}</div>}
       </div>
 
       <div className="form-group">
@@ -98,6 +97,7 @@ function CreateAccountPage() {
           onChange={handleInputChange}
           placeholder="Enter your email"
         />
+        {error && <div className="error-message">{error}</div>}
       </div>
 
       <div className="form-group">

--- a/frontend/src/tests/scenes/login/CreateAccountPage.test.jsx
+++ b/frontend/src/tests/scenes/login/CreateAccountPage.test.jsx
@@ -93,10 +93,10 @@ describe('CreateAccountPage', () => {
     // Add more assertions as needed
   });
 
-  it('handles sign up failure with user already exists error', async () => {
+  it('handles sign up failure with email already exists error', async () => {
     signUp.mockRejectedValueOnce({
       response: {
-        data: { error: 'User already exists' },
+        data: { error: 'Email already exists' },
         status: 400,
       },
     });
@@ -117,7 +117,7 @@ describe('CreateAccountPage', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText('User already exists')).to.exist;
+      expect(screen.getByText('Email already exists')).to.exist;
     });
 
     expect(signUp).toHaveBeenCalledWith({ username: 'testuser', email: 'test@example.com', password: 'Password1!' });


### PR DESCRIPTION
Fixes #175 

- Currently the backend auth function only checks if user exists, hence corrected the error message in response.
- moved the error message on frontend to email field