### PR TITLE
feat: [172] implementation toast notification

### DIFF
--- a/frontend/src/components/Header/DropdownMenu/DropdownMenu.jsx
+++ b/frontend/src/components/Header/DropdownMenu/DropdownMenu.jsx
@@ -6,14 +6,15 @@ import Person2OutlinedIcon from '@mui/icons-material/Person2Outlined';
 import LogoutOutlinedIcon from '@mui/icons-material/LogoutOutlined';
 import { useNavigate } from 'react-router-dom';
 import { logout } from '../../../services/loginServices';
+import toastEmitter, { TOAST_EMITTER_KEY } from '../../../utils/toastEmitter';
 
 const DropdownMenu = () => {
     const navigate = useNavigate();
 
     const handleLogoutClick = async () => {
-        const response = await logout();
-        console.log('Logout successful:', response);
-        window.location.reload();
+        await logout();
+        toastEmitter.emit(TOAST_EMITTER_KEY, 'Logout successfull');
+        window.location.reload(); // TODO: should remove reload func
         navigate('/');
     };
 

--- a/frontend/src/components/Toast/Toast.jsx
+++ b/frontend/src/components/Toast/Toast.jsx
@@ -1,0 +1,54 @@
+import React, { useEffect, useState } from 'react';
+import styles from './Toast.module.scss';
+import toastEmitter, { TOAST_EMITTER_KEY } from '../../utils/toastEmitter';
+import ToastItem from './ToastItem';
+import { defaultToastOptions, MAXIMUM_TOAST_COUNT } from './constant';
+
+const Toast = () => {
+  const [toasts, setToasts] = useState([]);
+  const [options, setOptions] = useState(defaultToastOptions);
+
+  useEffect(() => {
+    const handleNewToast = (message, options) => {
+      const newToast = { message: `${message}`, id: Date.now() };
+      setToasts((prevToasts) => {
+        const newArr = [...prevToasts, newToast];
+        return prevToasts.length < MAXIMUM_TOAST_COUNT ? newArr : newArr.slice(1);
+      });
+      options && setOptions({...defaultToastOptions, ...options})
+      setTimeout(() => {
+        setToasts((prevToasts) => prevToasts.filter((toast) => toast.id !== newToast.id));
+      }, 3000 + 500);
+    };
+
+    toastEmitter.on(TOAST_EMITTER_KEY, handleNewToast);
+
+    return () => {
+      toastEmitter.off(TOAST_EMITTER_KEY, handleNewToast);
+    };
+  }, []);
+
+  const closeToast = (id) => {
+    setToasts((prevToasts) => prevToasts.filter((toast) => toast.id !== id))
+  }
+
+  const containerStyle = {
+    top: options.top,
+  }
+
+  return (
+    <div className={styles.toastContainer} style={containerStyle}>
+      {toasts.map((toast) => (
+        <ToastItem 
+          key={toast?.id} 
+          id={toast.id} 
+          message={toast.message} 
+          closeToast={closeToast} 
+          options={options}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default Toast;

--- a/frontend/src/components/Toast/Toast.module.scss
+++ b/frontend/src/components/Toast/Toast.module.scss
@@ -1,0 +1,51 @@
+@use '../../styles/globals.scss' as *;
+
+
+.toastContainer {
+  position: fixed;
+  top: 110px;
+  right: 20px;
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  pointer-events: none;
+}
+
+.toast {
+  background-color: white;
+  border: 1px solid var(--light-border-color);
+  font-size: 13px;
+  line-height: 20px;
+  color: var(--third-text-color);
+  padding: 16px;
+  border-radius: 5px;
+  opacity: 0;
+  transform: translateX(100%);
+  transition: all 0.5s ease-out;
+  pointer-events: all;
+  max-width: 534px;
+  word-wrap: break-word;
+  box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
+  display: flex;
+  align-items: center;
+  gap: 10px
+}
+
+.text {
+  margin: 0;
+}
+
+.slideIn {
+  transform: translateX(0);
+  opacity: 1;
+}
+
+.slideOut {
+  transform: translateX(100%);
+  opacity: 0;
+}
+
+.icon {
+  cursor: pointer;
+}

--- a/frontend/src/components/Toast/ToastItem.jsx
+++ b/frontend/src/components/Toast/ToastItem.jsx
@@ -1,0 +1,48 @@
+import React, { useEffect, useState } from "react";
+import classNames from "classnames";
+import PropTypes from 'prop-types';
+import CloseIcon from '@mui/icons-material/Close';
+import styles from './Toast.module.scss';
+
+const ToastItem = ({ message, id, closeToast, options }) => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    // For animation slide-in
+    const animationTimeout = setTimeout(() => {
+      setIsVisible(true);
+    }, 0)
+    const timeout = setTimeout(() => {
+      setIsVisible(false);
+    }, options.duration);
+
+    return () => {
+      clearTimeout(timeout);
+      clearTimeout(animationTimeout);
+    };
+  }, []);
+
+  const handleClose = () => {
+    setIsVisible(false);
+    // For animation slide out
+    setTimeout(() => {
+      closeToast(id)
+    },300)
+  }
+
+  return (
+    <div className={classNames(styles.toast, { [styles.slideIn]: isVisible, [styles.slideOut]: !isVisible})} key={id}>
+      <p className={styles.text}>{message}</p>
+      <CloseIcon onClick={handleClose} className={styles.icon} />
+    </div>
+  );
+};
+
+ToastItem.propTypes = {
+  message: PropTypes.string,
+  id: PropTypes.number,
+  closeToast: PropTypes.func,
+  options: PropTypes.object
+}
+
+export default ToastItem;

--- a/frontend/src/components/Toast/constant.js
+++ b/frontend/src/components/Toast/constant.js
@@ -1,0 +1,6 @@
+export const defaultToastOptions = {
+  duration: 3000,
+  top: '110px',
+}
+
+export const MAXIMUM_TOAST_COUNT = 8;

--- a/frontend/src/index.jsx
+++ b/frontend/src/index.jsx
@@ -6,10 +6,13 @@ import { BrowserRouter as Router} from "react-router-dom";
 import theme from "./assets/theme.js";
 import { ThemeProvider } from "@mui/material";
 import { AuthProvider } from "./services/authProvider.jsx";
+import Toast from "./components/Toast/Toast.jsx";
+
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
     <ThemeProvider theme={theme}>
       <AuthProvider>
+        <Toast />
         <Router>
           <App />
         </Router>

--- a/frontend/src/scenes/bannerPage/BannerPage.jsx
+++ b/frontend/src/scenes/bannerPage/BannerPage.jsx
@@ -6,6 +6,7 @@ import { React, useState, useEffect } from 'react';
 import BannerPreview from '../../components/BannerPageComponents/BannerPreview/BannerPreview';
 import { addBanner, getBannerById, editBanner } from '../../services/bannerServices';
 import { useNavigate, useLocation } from 'react-router-dom';
+import toastEmitter, { TOAST_EMITTER_KEY } from '../../utils/toastEmitter';
 
 const BannerPage = () => {
     const navigate = useNavigate();
@@ -64,7 +65,8 @@ const BannerPage = () => {
             const response = location.state?.isEdit
             ? await editBanner(location.state?.id, bannerData)
             : await addBanner(bannerData);
-            console.log('Add banner successful:', response);
+            const toastMessage = location.state?.isEdit ? 'You edited this banner' : 'New banner saved'
+            toastEmitter.emit(TOAST_EMITTER_KEY, toastMessage);
             navigate('/banner');
         } catch (error) {
             if (error.response && error.response.data) {

--- a/frontend/src/scenes/login/LoginPage.jsx
+++ b/frontend/src/scenes/login/LoginPage.jsx
@@ -4,6 +4,7 @@ import GoogleSignInButton from '../../components/Button/GoogleSignInButton/Googl
 import { login } from '../../services/loginServices';
 import { useNavigate } from 'react-router-dom';
 import CustomLink from '../../components/CustomLink/CustomLink';
+import toastEmitter, { TOAST_EMITTER_KEY } from '../../utils/toastEmitter';
 
 function LoginPage() {
   const [email, setEmail] = useState('');
@@ -16,9 +17,9 @@ function LoginPage() {
   const handleLogin = async () => {
     try {
       const response = await login(email, password);
-      console.log('Login successful:', response);
-      window.location.reload();
-      navigate('/');
+      toastEmitter.emit(TOAST_EMITTER_KEY, `Login successfull`)
+      window.location.reload(); // TODO: should remove reload func
+      navigate('/home');
     } catch (error) {
       setLoginError(true);
       setErrorMessage(error.response.data.error);

--- a/frontend/src/scenes/popup/CreatePopupPage.jsx
+++ b/frontend/src/scenes/popup/CreatePopupPage.jsx
@@ -6,6 +6,7 @@ import PopupAppearance from '../../components/PopupPageComponents/PopupAppearanc
 import PopupContent from '../../components/PopupPageComponents/PopupContent/PopupContent';
 import { addPopup, getPopupById, editPopup } from '../../services/popupServices';
 import { useNavigate, useLocation } from 'react-router-dom';
+import toastEmitter, { TOAST_EMITTER_KEY } from '../../utils/toastEmitter';
 
 
 const CreatePopupPage = () => {
@@ -84,13 +85,14 @@ const CreatePopupPage = () => {
             header: header,
             content: content
         };
-        console.log(popupData)
         try {
             const response = location.state?.isEdit
             ? await editPopup(location.state?.id, popupData)
             : await addPopup(popupData);
             
-            console.log('Add popup successful:', response);
+            const toastMessage = location.state?.isEdit ? 'You edited this popup' : 'This popup is removed'
+
+            toastEmitter.emit(TOAST_EMITTER_KEY, toastMessage)
             navigate('/popup');
         } catch (error) {
             if (error.response && error.response.data) {

--- a/frontend/src/scenes/popup/CreatePopupPage.jsx
+++ b/frontend/src/scenes/popup/CreatePopupPage.jsx
@@ -90,7 +90,7 @@ const CreatePopupPage = () => {
             ? await editPopup(location.state?.id, popupData)
             : await addPopup(popupData);
             
-            const toastMessage = location.state?.isEdit ? 'You edited this popup' : 'This popup is removed'
+            const toastMessage = location.state?.isEdit ? 'You edited this popup' : 'New popup Saved'
 
             toastEmitter.emit(TOAST_EMITTER_KEY, toastMessage)
             navigate('/popup');

--- a/frontend/src/scenes/popup/PopupDefaultPage.jsx
+++ b/frontend/src/scenes/popup/PopupDefaultPage.jsx
@@ -8,6 +8,7 @@ import GuideMainPageTemplate from "../../templates/GuideMainPageTemplate/GuideMa
 import { getPopups } from "../../services/popupServices"; 
 import { ACTIVITY_TYPES_INFO } from '../../data/GuideMainPageData';
 import { deletePopup } from '../../services/popupServices';
+import toastEmitter, { TOAST_EMITTER_KEY } from '../../utils/toastEmitter';
 
 const PopupDefaultPage = () => {
     const navigate = useNavigate();
@@ -25,6 +26,7 @@ const PopupDefaultPage = () => {
         await deletePopup(popupToDelete)
         setPopupOpen(false);
         setPopupDeleted(prevState => !prevState);
+        toastEmitter.emit(TOAST_EMITTER_KEY, 'This popup is removed')
     };
 
     const handleOpenPopup = (id) => {

--- a/frontend/src/templates/DefaultPageTemplate/DefaultPageTemplate.jsx
+++ b/frontend/src/templates/DefaultPageTemplate/DefaultPageTemplate.jsx
@@ -4,6 +4,7 @@ import HomePageTemplate from '../HomePageTemplate/HomePageTemplate';
 import ParagraphCSS from '../../components/ParagraphCSS/ParagraphCSS';
 import GuideMainPageTemplate from '../GuideMainPageTemplate/GuideMainPageTemplate';
 import CreateActivityButton from '../../components/Button/CreateActivityButton/CreateActivityButton';
+import toastEmitter, { TOAST_EMITTER_KEY } from '../../utils/toastEmitter';
 
 const DefaultPageTemplate = ({ getItems, deleteItem, navigateToCreate, itemType, itemTypeInfo, getItemDetails }) => {
     const [items, setItems] = useState([]);
@@ -15,6 +16,7 @@ const DefaultPageTemplate = ({ getItems, deleteItem, navigateToCreate, itemType,
         await deleteItem(itemToDelete);
         setPopupOpen(false);
         setItemDeleted(prevState => !prevState);
+        toastEmitter.emit(TOAST_EMITTER_KEY, 'This banner is removed');
     };
 
     const handleOpenPopup = (id) => {

--- a/frontend/src/tests/components/Toast/Toast.test.jsx
+++ b/frontend/src/tests/components/Toast/Toast.test.jsx
@@ -1,0 +1,54 @@
+import { render, screen, act } from '@testing-library/react';
+import { describe, it, vi, expect } from 'vitest';
+import '@testing-library/jest-dom';
+import toastEmitter, { TOAST_EMITTER_KEY } from '../../../utils/toastEmitter';
+import Toast from '../../../components/Toast/Toast';
+
+describe('Toast Component', () => {
+  it('should display a toast message', () => {
+    render(<Toast />);
+
+    act(() => {
+      toastEmitter.emit(TOAST_EMITTER_KEY, 'Test Toast Message', { top: '20px' });
+    });
+
+    const toastElement = screen.getByText('Test Toast Message');
+    expect(toastElement).not.toBeNull();
+  });
+
+  it('should automatically remove the toast after timeout', () => {
+    vi.useFakeTimers();
+
+    render(<Toast />);
+
+    act(() => {
+      toastEmitter.emit(TOAST_EMITTER_KEY, 'Auto Remove Toast', { top: '20px' });
+    });
+
+    const toastElement = screen.getByText('Auto Remove Toast');
+    expect(toastElement).toBeInTheDocument();
+
+
+    act(() => {
+      vi.advanceTimersByTime(3500);
+    });
+
+    expect(toastElement).not.toBeInTheDocument();
+  });
+
+  it('should respect maximum toast count for max 8 count', () => {
+    render(<Toast />);
+
+    act(() => {
+      for (let i = 1; i <= 9; i++) {
+        toastEmitter.emit(TOAST_EMITTER_KEY, `Toast ${i}`, { top: '20px' });
+      }
+    });
+
+    expect(screen.getByText('Toast 6')).toBeInTheDocument();
+    expect(screen.getByText('Toast 7')).toBeInTheDocument();
+    expect(screen.getByText('Toast 8')).toBeInTheDocument();
+    
+    expect(screen.queryByText('Toast 1')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/components/Toast/ToastItem.test.jsx
+++ b/frontend/src/tests/components/Toast/ToastItem.test.jsx
@@ -1,0 +1,72 @@
+// ToastItem.test.tsx
+import { render, screen, act, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, vi, expect } from 'vitest';
+import '@testing-library/jest-dom';
+import ToastItem from '../../../components/Toast/ToastItem';
+
+
+vi.mock('@mui/icons-material/Close', () => ({
+  default: vi.fn(() => <div>CloseIcon</div>)
+}));
+
+vi.mock('../../../components/Toast/Toast.module.scss', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    toast: 'toast',
+    slideIn: 'slideIn',
+    slideOut: 'slideOut',
+    text: 'text',
+    icon: 'icon',
+    ...actual
+  }
+});
+
+describe('ToastItem Component', () => {
+  const mockCloseToast = vi.fn()
+  const mockOptions = { duration: 3000 };
+
+  it('should render toast message', () => {
+    render(<ToastItem message="Test Toast" id={1} closeToast={mockCloseToast} options={mockOptions} />);
+    
+    expect(screen.getByText('Test Toast')).toBeInTheDocument();
+    expect(screen.getByText('CloseIcon')).toBeInTheDocument(); // Close icon should be visible
+  });
+
+  it('should apply slide-in animation when toast is visible', () => {
+    vi.useFakeTimers();
+    
+    render(<ToastItem message="Test Toast" id={1} closeToast={mockCloseToast} options={mockOptions} />);
+
+    expect(screen.getByText('Test Toast').parentElement).toHaveClass('toast');
+    
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+    
+    expect(screen.getByText('Test Toast').parentElement).toHaveClass('slideIn');
+  });
+
+  it('should remove toast after duration and apply slide-out animation', () => {
+    vi.useFakeTimers();
+
+    render(<ToastItem message="Test Toast" id={1} closeToast={mockCloseToast} options={mockOptions} />);
+
+    act(() => {
+      vi.advanceTimersByTime(mockOptions.duration);
+    });
+
+    expect(screen.getByText('Test Toast').parentElement).toHaveClass('slideOut');
+    
+  });
+
+  it('should close toast when close icon is clicked', async () => {
+    const closeToast = vi.fn(); // Mock closeToast function
+
+    render(<ToastItem message="Test Toast" id={1} closeToast={closeToast} options={mockOptions} />);
+
+    fireEvent.click(screen.getByText('CloseIcon'));
+
+    expect(screen.getByText('Test Toast').parentElement).toHaveClass('slideOut');
+      
+  });
+});

--- a/frontend/src/utils/toastEmitter.js
+++ b/frontend/src/utils/toastEmitter.js
@@ -1,0 +1,7 @@
+import { EventEmitter } from 'events';
+
+const toastEmitter = new EventEmitter();
+
+export const TOAST_EMITTER_KEY = 'showToast';
+
+export default toastEmitter;

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -7,6 +7,11 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
-    include: ['src/tests/**/*.test.jsx']
-  },
+    include: ['src/tests/**/*.test.jsx'],
+    css: {
+      modules: {
+          classNameStrategy: 'non-scoped'
+      }
+    }
+  }
 });


### PR DESCRIPTION
I built a structure with `EventEmitter` to manage Toast notifications.

I didn't want to do it with React context because toast is a component that will be triggered frequently, so there will be unnecessary re-renders.

If we used Context, we would only be able to trigger toast in jsx files. With Event emitter we can also trigger toast in js files.
I didn't use an extra library for toast. I developed a component for our current need.

https://github.com/user-attachments/assets/ed853052-ed96-4868-80a2-e1b65e7afac0

<img width="1115" alt="image" src="https://github.com/user-attachments/assets/6ef67ead-50f0-4144-9b38-efaaade45f44">


