### PR TITLE
update seeder to use correct column "name" and hashed password

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -7,6 +7,5 @@ DEV_DB_PASSWORD=password123
 DEV_DB_NAME=onboarding_db
 DEV_DB_HOST=localhost
 DEV_DB_PORT=5432
-JWT_SECRET=your_development_jwt_secret
 
 EMAIL_ENABLE=false

--- a/backend/.env
+++ b/backend/.env
@@ -7,5 +7,6 @@ DEV_DB_PASSWORD=password123
 DEV_DB_NAME=onboarding_db
 DEV_DB_HOST=localhost
 DEV_DB_PORT=5432
+JWT_SECRET=your_development_jwt_secret
 
 EMAIL_ENABLE=false

--- a/backend/seeders/20240610054534-demo-users.js
+++ b/backend/seeders/20240610054534-demo-users.js
@@ -1,10 +1,8 @@
 "use strict";
 
-const bcrypt = require('bcrypt');
-
 module.exports = {
   up: async (queryInterface, Sequelize) => {
-    const hashedPassword = await bcrypt.hash('password123', 10);
+    const hashedPassword = "$2b$10$tQiyc0NpG9UFoH6k6j6IbuPcZNFZFUkFMC28r9752WLqlDB.sIzC." //password123
     await queryInterface.bulkInsert(
       "users",
       [

--- a/backend/seeders/20240610054534-demo-users.js
+++ b/backend/seeders/20240610054534-demo-users.js
@@ -1,35 +1,38 @@
 "use strict";
 
+const bcrypt = require('bcrypt');
+
 module.exports = {
   up: async (queryInterface, Sequelize) => {
+    const hashedPassword = await bcrypt.hash('password123', 10);
     await queryInterface.bulkInsert(
       "users",
       [
         {
-          username: "demoUser1",
+          name: "demoUser1",
           email: "demo1@example.com",
-          password: "password123",
+          password: hashedPassword,
           role: "user",
           createdAt: new Date(),
         },
         {
-          username: "demoUser2",
+          name: "demoUser2",
           email: "demo2@example.com",
-          password: "password123",
+          password: hashedPassword,
           role: "user",
           createdAt: new Date(),
         },
         {
-          username: "demoUser3",
+          name: "demoUser3",
           email: "demo3@example.com",
-          password: "password123",
+          password: hashedPassword,
           role: "user",
           createdAt: new Date(),
         },
         {
-          username: "demoUser4",
+          name: "demoUser4",
           email: "demo4@example.com",
-          password: "password123",
+          password: hashedPassword,
           role: "user",
           createdAt: new Date(),
         },


### PR DESCRIPTION
line 35 bcrypt comparison is breaking due to storage of unhashed password in db

![image](https://github.com/user-attachments/assets/722fd14d-72ea-48f0-b1bb-0715919af2cb)
