### PR TITLE
Fix: Disable the login button in the LoginPage and the signup button in the SignupPage while the user clicks it and a loader is visible. #281

### DIFF
--- a/frontend/src/scenes/login/CreateAccountPage.jsx
+++ b/frontend/src/scenes/login/CreateAccountPage.jsx
@@ -165,7 +165,7 @@ function CreateAccountPage() {
         Must contain one special character
       </div>
 
-      <button className={styles["create-account-button"]} type="submit">
+      <button className={styles["create-account-button"]} type="submit" disabled={loading}>
         {loading ? <CircularProgress size={12} color="inherit" /> : "Get started"}
       </button>
       <div className={styles["sign-up-link"]}>

--- a/frontend/src/scenes/login/LoginPage.jsx
+++ b/frontend/src/scenes/login/LoginPage.jsx
@@ -91,7 +91,7 @@ function LoginPage() {
           <CustomLink text="Forgot Password" url="/forgot-password" />
         </div>
       </div>
-      <button className={styles["sign-in-button"]} type="submit">
+      <button className={styles["sign-in-button"]} type="submit" disabled={loading}>
         {loading ? <CircularProgress size={12} color="inherit" /> : 'Sign In'}
       </button>
       <div className={styles["sign-up-link"]}>


### PR DESCRIPTION
This PR includes: disable login and signup buttons while loading

Fixes [https://github.com/bluewave-labs/bluewave-onboarding/issues/281](https://github.com/bluewave-labs/bluewave-onboarding/issues/281)

**Mandatory Tasks**

- [x] Make sure you have self-reviewed the code. A decent-sized PR without self-review might be rejected.