### PR TITLE
Refactor: Update font sizes to use CSS variables

### DIFF
--- a/frontend/src/components/Button/CreateActivityButton/CreateActivityButtonStyles.css
+++ b/frontend/src/components/Button/CreateActivityButton/CreateActivityButtonStyles.css
@@ -1,40 +1,40 @@
 @import "../../../styles/variables.css";
 
-.bannerStyle{
+.bannerStyle {
     display: flex;
     justify-content: center;
     align-items: center;
     flex-direction: column;
 }
 
-.heading{
+.heading {
     color: var(--main-text-color);
     font-weight: 600;
     margin-bottom: 15px;
     font-size: 16px;
 }
 
-.list{
+.list {
     display: flex;
     align-items: center;
     gap: 15px;
     padding: 5px;
 }
 
-.listText{
+.listText {
     color: var(--main-text-color);
     font-weight: 400;
-    font-size: 13px;
+    font-size: var(--font-regular);
     margin-bottom: 10px;
     list-style-type: none;
 }
 
-.bannerContents{
+.bannerContents {
     display: flex;
     flex-direction: column;
-    align-items: center; 
+    align-items: center;
 }
 
-.button{
+.button {
     margin-top: 10px;
 }

--- a/frontend/src/components/Button/GoogleSignInButton/GoogleSignInButton.css
+++ b/frontend/src/components/Button/GoogleSignInButton/GoogleSignInButton.css
@@ -1,20 +1,19 @@
 .google-sign-in-button {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 100%;
-    padding: 5px;
-    margin-bottom: 30px;
-    border: 1px solid #D0D5DD;
-    border-radius: 8px;
-    color: var(--main-text-color);
-    box-shadow: 0px 1px 2px 0px #1018280D;
-    cursor: pointer;
-    font-size: 13px;
-    background-color: #fff;
-  }
-  
-  .google-icon {
-    margin-right: 8px;
-  }
-  
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  padding: 5px;
+  margin-bottom: 30px;
+  border: 1px solid #D0D5DD;
+  border-radius: 8px;
+  color: var(--main-text-color);
+  box-shadow: 0px 1px 2px 0px #1018280D;
+  cursor: pointer;
+  font-size: var(--font-regular);
+  background-color: #fff;
+}
+
+.google-icon {
+  margin-right: 8px;
+}

--- a/frontend/src/components/ColorTextField/ColorTextField.module.scss
+++ b/frontend/src/components/ColorTextField/ColorTextField.module.scss
@@ -1,31 +1,29 @@
-@use '../../styles/globals.scss' as *;
+@use "../../styles/globals.scss" as *;
 
 .colorTextField {
+  :global {
+    .MuiOutlinedInput-root {
+      &:hover fieldset {
+        border-color: var(--main-purple);
+      }
 
-    :global {
-        .MuiOutlinedInput-root {
-            &:hover fieldset {
-                border-color: var(--main-purple);
-            }
-
-            &.Mui-focused fieldset {
-                border-color: var(--main-purple);
-            }
-
-        }
+      &.Mui-focused fieldset {
+        border-color: var(--main-purple);
+      }
     }
+  }
 
-    input {
-        font-size: 13px;
-        height: 34px;
-        padding-top: 0;
-        padding-bottom: 0;
-    }
+  input {
+    font-size: var(--font-regular);
+    height: 34px;
+    padding-top: 0;
+    padding-bottom: 0;
+  }
 
-    button {
-        height: 17px;
-        width: 17px;
-        box-shadow: none;
-        border: 1.23px solid var(--grey-border);
-    }
+  button {
+    height: 17px;
+    width: 17px;
+    box-shadow: none;
+    border: 1.23px solid var(--grey-border);
+  }
 }

--- a/frontend/src/components/DropdownMenu/DropdownMenu.css
+++ b/frontend/src/components/DropdownMenu/DropdownMenu.css
@@ -1,42 +1,41 @@
 .dropdown-menu {
-    position: absolute;
-    bottom: calc(8vh + 10px); 
-    min-width: fit-content;
-    z-index: 1;
+  position: absolute;
+  bottom: calc(8vh + 10px);
+  min-width: fit-content;
+  z-index: 1;
 }
 
 .dropdown-menu .MuiListItem-root {
-    cursor: pointer;
+  cursor: pointer;
 }
 
 .dropdown-menu .MuiListItem-root:hover {
-    background-color: #F9FAFB;
+  background-color: #F9FAFB;
 }
 
-.dropdown-item .MuiTypography-root{
-    width: 100%; 
-    font-size: 13px;
-    font-weight: 400;
-    line-height: 24px;
-    color: var(--main-text-color);
-    display: inline;
-    justify-content: center;
-  }
+.dropdown-item .MuiTypography-root {
+  width: 100%;
+  font-size: var(--font-regular);
+  font-weight: 400;
+  line-height: 24px;
+  color: var(--main-text-color);
+  display: inline;
+  justify-content: center;
+}
 
-  .dropdown-item {
-    padding: 4px 12px !important; 
-  }
+.dropdown-item {
+  padding: 4px 12px !important;
+}
 
-  .dropdown-list{
-    padding-top: 4px !important;
-    padding-bottom: 4px !important;
-  }
+.dropdown-list {
+  padding-top: 4px !important;
+  padding-bottom: 4px !important;
+}
 
-  .dropdown-menu .MuiSvgIcon-root{
-    color:var(--second-text-color);
-  }
+.dropdown-menu .MuiSvgIcon-root {
+  color: var(--second-text-color);
+}
 
-  .dropdown-menu .MuiListItemIcon-root {
-    min-width: 2rem; 
-  }
-
+.dropdown-menu .MuiListItemIcon-root {
+  min-width: 2rem;
+}

--- a/frontend/src/components/Header/Header.css
+++ b/frontend/src/components/Header/Header.css
@@ -1,57 +1,54 @@
-
 .top-banner {
-    background-color: #ffffff; 
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 10px 20px;
-    height: 8vh;
-    top: 0; 
-    left: 0; 
-    box-shadow: 0px 3px 3px -3px var(--shadow-one);
-    box-shadow: 0px 4px 24px -4px var(--shadow-two);
+  background-color: #ffffff;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 20px;
+  height: 8vh;
+  top: 0;
+  left: 0;
+  box-shadow: 0px 3px 3px -3px var(--shadow-one);
+  box-shadow: 0px 4px 24px -4px var(--shadow-two);
 
-  }
-  
-  .user-info {
-    display: flex;
-    align-items: center;
-    margin-right: 20px;
-  }
-  
-  
-  .user-details {
-    display: flex;
-    flex-direction: column;
-  }
-  
-  .user-name{
-    font-size: 13px;
-    font-weight: 600;
-    line-height: 20px;
-    color: var(--main-text-color);
-  }
+}
 
-  .user-role {
-    margin: 0; 
-    font-size: 13px;
-    font-weight: 400;
-    line-height: 20px;
-    color: var(--main-text-color);
-  }
-  
-  .logo {
-    color: #FF834E;
-    font-size: 20px; 
-    font-weight: 600;
-  }
+.user-info {
+  display: flex;
+  align-items: center;
+  margin-right: 20px;
+}
+
+
+.user-details {
+  display: flex;
+  flex-direction: column;
+}
+
+.user-name {
+  font-size: var(--font-regular);
+  font-weight: 600;
+  line-height: 20px;
+  color: var(--main-text-color);
+}
+
+.user-role {
+  margin: 0;
+  font-size: var(--font-regular);
+  font-weight: 400;
+  line-height: 20px;
+  color: var(--main-text-color);
+}
+
+.logo {
+  color: #FF834E;
+  font-size: 20px;
+  font-weight: 600;
+}
 
 .dropdown-button {
-    background-color: transparent; 
-    border: none; 
-    cursor: pointer; 
-    padding: 0.4em 0.4em;
-    margin: 1px
-  }
-  
-  
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 0.4em 0.4em;
+  margin: 1px
+}

--- a/frontend/src/components/HeadingTabs/TabStyles.css
+++ b/frontend/src/components/HeadingTabs/TabStyles.css
@@ -1,23 +1,25 @@
 .MuiTab-root {
-    font-family: 'Inter', sans-serif;
-    font-size: 13px;
-    font-style: normal;
-    font-weight: 400;
-    line-height: 20px;
-  }
+  font-family: 'Inter', sans-serif;
+  font-size: var(--font-regular);
+  font-style: normal;
+  font-weight: 400;
+  line-height: 20px;
+}
+
 .MuiTabs-root .MuiTab-root.Mui-selected {
-    color: var(--main-purple);
-  }
+  color: var(--main-purple);
+}
 
 .MuiTabs-root .MuiTab-root:not(.Mui-selected) {
-color: var(--main-text-color);
-border-bottom: 1px solid var(--Colors-Foreground-fg-brand-primary_alt, #EAECF0);
+  color: var(--main-text-color);
+  border-bottom: 1px solid var(--Colors-Foreground-fg-brand-primary_alt, #EAECF0);
 }
 
 .MuiTabs-root .MuiTabs-indicator {
-background-color: var(--main-purple);
+  background-color: var(--main-purple);
 }
-.container-tabs{
+
+.container-tabs {
   padding: 45px;
   width: 980px;
   height: 1067px;
@@ -26,11 +28,12 @@ background-color: var(--main-purple);
   border: 1px solid #EBEBEB;
   background: #FFF;
 }
-.tabs-row{
+
+.tabs-row {
   display: flex;
-width: 980px;
-flex-direction: column;
-align-items: flex-start;
-gap: var(--spacing-md, 8px);
-border-bottom: 1px solid var(--Colors-Border-border-secondary, #EAECF0);
+  width: 980px;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--spacing-md, 8px);
+  border-bottom: 1px solid var(--Colors-Border-border-secondary, #EAECF0);
 }

--- a/frontend/src/components/HintPageComponents/HintLeftAppearance/HintLeftAppearance.css
+++ b/frontend/src/components/HintPageComponents/HintLeftAppearance/HintLeftAppearance.css
@@ -9,7 +9,7 @@
   margin-top: 1.5rem;
   margin-bottom: 0.5rem;
   font-weight: 400;
-  font-size: 13px;
+  font-size: var(--font-regular);
 }
 
 .hint-appearance-color {

--- a/frontend/src/components/HintPageComponents/HintLeftContent/HintLeftContent.css
+++ b/frontend/src/components/HintPageComponents/HintLeftContent/HintLeftContent.css
@@ -9,6 +9,6 @@
 
 .hint-label {
     font-weight: 400;
-    font-size: 13px;
+    font-size: var(--font-regular);
     margin-top: 1.5rem;
 }

--- a/frontend/src/components/HomePageComponents/DateDisplay/DateDisplay.module.scss
+++ b/frontend/src/components/HomePageComponents/DateDisplay/DateDisplay.module.scss
@@ -1,8 +1,7 @@
-.date{
-    font-family: Inter;
-    font-size: 13px;
-    font-weight: 400;
-    line-height: 24px;
-    text-align: left;
-
+.date {
+  font-family: Inter;
+  font-size: var(--font-regular);
+  font-weight: 400;
+  line-height: 24px;
+  text-align: left;
 }

--- a/frontend/src/components/HomePageComponents/StatisticCards/StatisticCards.module.scss
+++ b/frontend/src/components/HomePageComponents/StatisticCards/StatisticCards.module.scss
@@ -1,47 +1,44 @@
-@import url('../../../styles/variables.css');
+@import url("../../../styles/variables.css");
 
 .statisticCard {
-    border: 1px solid var(--light-gray);
-    border-radius: 12px;
-    padding: 24px;
-    gap:10px;
-    display: flex;
-    flex-direction: column;
-    width: 100%;
-    box-shadow: 0px 1px 2px 0px #1018280D;
+  border: 1px solid var(--light-gray);
+  border-radius: 12px;
+  padding: 24px;
+  gap: 10px;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  box-shadow: 0px 1px 2px 0px #1018280d;
 
-
-    .metricName {
-        font-size: 16px;
-        font-weight: 600;
-        line-height: 24px;
-        margin-bottom: 13px;
-    }
-  
-    .metricValue {
-        font-size: 36px;
-        font-weight: 600;
-        line-height: 44px;
-        letter-spacing: -0.02em;
-    }
-  
-    .changeRate {
-        font-size: 13px;
-        font-weight: 400;
-        line-height: 20px;
-        color: var(--third-text-color);    
-        align-items: center;
-        flex-direction: row;
-        display: flex;
-    }
-    .change{
-        align-items: center;
-        display: flex;
-        font-family: Inter;
-        font-size: 14px;
-        font-weight: 600;
-        line-height: 20px;
-    }
-
+  .metricName {
+    font-size: 16px;
+    font-weight: 600;
+    line-height: 24px;
+    margin-bottom: 13px;
   }
-  
+
+  .metricValue {
+    font-size: 36px;
+    font-weight: 600;
+    line-height: 44px;
+    letter-spacing: -0.02em;
+  }
+
+  .changeRate {
+    font-size: var(--font-regular);
+    font-weight: 400;
+    line-height: 20px;
+    color: var(--third-text-color);
+    align-items: center;
+    flex-direction: row;
+    display: flex;
+  }
+  .change {
+    align-items: center;
+    display: flex;
+    font-family: Inter;
+    font-size: 14px;
+    font-weight: 600;
+    line-height: 20px;
+  }
+}

--- a/frontend/src/components/LeftMenu/LeftMenu.css
+++ b/frontend/src/components/LeftMenu/LeftMenu.css
@@ -14,7 +14,7 @@
 }
 
 .title .MuiTypography-root {
-  font-size: 11px;
+  font-size: var(--font-informative);
   font-weight: 400;
   line-height: 38px;
   color: #98A2B3;
@@ -38,7 +38,7 @@
 
 .menu-item .MuiTypography-root {
   width: 100%;
-  font-size: 13px;
+  font-size: var(--font-regular);
   font-weight: 400;
   line-height: 24px;
   color: var(--main-text-color);

--- a/frontend/src/components/RichTextEditor/RichTextEditor.css
+++ b/frontend/src/components/RichTextEditor/RichTextEditor.css
@@ -3,7 +3,7 @@
   flex-direction: column;
   margin: 0 auto;
   color: var(--main-text-color);
-  font-size: 13px;
+  font-size: var(--font-regular);
   height: auto;
 }
 

--- a/frontend/src/components/Settings/Settings.module.scss
+++ b/frontend/src/components/Settings/Settings.module.scss
@@ -1,15 +1,15 @@
-@use '../../styles/globals.scss' as *;
+@use "../../styles/globals.scss" as *;
 
 .settings {
   box-shadow: 0px 8px 8px -4px var(--shadow-one);
   box-shadow: 0px 20px 24px -4px var(--shadow-two);
-  border: 1px solid #D0D5DD;
+  border: 1px solid #d0d5dd;
   max-width: 460px;
 
   .smallText {
     font-weight: 400;
     line-height: 20px;
-    font-size: 11px;
+    font-size: var(--font-informative);
     color: var(--second-text-color);
     margin-bottom: 20px;
   }
@@ -20,7 +20,7 @@
     padding: 5px;
     margin-bottom: 16px;
     border: 1px solid var(--light-border-color);
-    box-shadow: 0px 1px 2px 0px #1018280D;
+    box-shadow: 0px 1px 2px 0px #1018280d;
     width: 100%;
     height: 1.4rem;
     border-radius: 0.5rem;
@@ -29,7 +29,7 @@
   select {
     @include text-style(regular);
     color: var(--second-text-color);
-    box-shadow: 0px 1px 2px 0px #1018280D;
+    box-shadow: 0px 1px 2px 0px #1018280d;
   }
 
   .switch {

--- a/frontend/src/components/TextFieldComponents/CustomTextField/CustomTextFieldStyles.css
+++ b/frontend/src/components/TextFieldComponents/CustomTextField/CustomTextFieldStyles.css
@@ -11,7 +11,7 @@
 }
 
 .textField .MuiOutlinedInput-root {
-  font-size: 13px;
+  font-size: var(--font-regular);
   box-shadow: 0px 1px 2px 0px #1018280d;
 }
 
@@ -19,6 +19,7 @@
   &:hover fieldset {
     border-color: var(--main-purple);
   }
+
   &.Mui-focused fieldset {
     border-color: var(--main-purple);
   }
@@ -26,11 +27,11 @@
 }
 
 .textField .MuiButton-root {
-  font-size: 13px;
+  font-size: var(--font-regular);
   color: var(--second-text-color);
 }
 
 .MuiBox-root .MuiInputLabel-root {
-  font-size: 13px;
+  font-size: var(--font-regular);
   color: var(--second-text-color);
 }

--- a/frontend/src/components/Toast/Toast.module.scss
+++ b/frontend/src/components/Toast/Toast.module.scss
@@ -1,5 +1,4 @@
-@use '../../styles/globals.scss' as *;
-
+@use "../../styles/globals.scss" as *;
 
 .toastContainer {
   position: fixed;
@@ -15,7 +14,7 @@
 .toast {
   background-color: white;
   border: 1px solid var(--light-border-color);
-  font-size: 13px;
+  font-size: var(--font-regular);
   line-height: 20px;
   color: var(--third-text-color);
   padding: 16px;
@@ -29,7 +28,7 @@
   box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
   display: flex;
   align-items: center;
-  gap: 10px
+  gap: 10px;
 }
 
 .text {

--- a/frontend/src/components/UserProfileSidebar/UserProfileSidebar.module.css
+++ b/frontend/src/components/UserProfileSidebar/UserProfileSidebar.module.css
@@ -18,7 +18,7 @@
 }
 
 .user-name {
-    font-size: 13px;
+    font-size: var(--font-regular);
     font-weight: 600;
     line-height: 20px;
     color: var(--main-text-color);
@@ -26,7 +26,7 @@
 
 .user-role {
     margin: 0;
-    font-size: 13px;
+    font-size: var(--font-regular);
     font-weight: 400;
     line-height: 20px;
     color: var(--main-text-color);

--- a/frontend/src/scenes/errors/Error.module.scss
+++ b/frontend/src/scenes/errors/Error.module.scss
@@ -22,7 +22,7 @@
     }
 
     .infoText {
-      font-size: 13px;
+      font-size: var(--font-regular);
       font-weight: 400;
       line-height: 23px;
     }

--- a/frontend/src/scenes/login/ForgotPassword.css
+++ b/frontend/src/scenes/login/ForgotPassword.css
@@ -38,7 +38,7 @@
   text-align: center;
   /* font-weight: 500; */
   margin-bottom: 30px;
-  font-size: 13px;
+  font-size: var(--font-regular);
   font-weight: 400;
   line-height: 24px;
 }
@@ -52,7 +52,7 @@
   margin-top: 5px;
   color: var(--second-text-color);
   cursor: pointer;
-  font-size: 13px;
+  font-size: var(--font-regular);
   background-color: transparent;
   border: none;
   outline: none;
@@ -64,7 +64,7 @@
 
 .error-message {
   color: #D92D20;
-  font-size: 13px;
+  font-size: var(--font-regular);
   font-weight: 400;
   margin-bottom: 1rem;
   margin-top: 0.25rem;

--- a/frontend/src/scenes/login/Login.css
+++ b/frontend/src/scenes/login/Login.css
@@ -23,8 +23,8 @@
   width: 360px;
   margin: 0 auto;
   padding: 20px;
-  font-family: 'Inter', sans-serif; 
-  background-repeat: no-repeat; 
+  font-family: 'Inter', sans-serif;
+  background-repeat: no-repeat;
   background-image: url('data:image/svg+xml,<svg width="768" height="768" viewBox="0 0 768 768" fill="none" xmlns="http://www.w3.org/2000/svg"><mask id="mask0_52_53336" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="768" height="768"><rect width="768" height="768" fill="url(%23paint0_radial_52_53336)"/></mask><g mask="url(%23mask0_52_53336)"><g clip-path="url(%23clip0_52_53336)"><g clip-path="url(%23clip1_52_53336)"><line x1="0.5" x2="0.5" y2="768" stroke="%23EAECF0"/><line x1="48.5" x2="48.5" y2="768" stroke="%23EAECF0"/><line x1="96.5" x2="96.5" y2="768" stroke="%23EAECF0"/><line x1="144.5" x2="144.5" y2="768" stroke="%23EAECF0"/><line x1="192.5" x2="192.5" y2="768" stroke="%23EAECF0"/><line x1="240.5" x2="240.5" y2="768" stroke="%23EAECF0"/><line x1="288.5" x2="288.5" y2="768" stroke="%23EAECF0"/><line x1="336.5" x2="336.5" y2="768" stroke="%23EAECF0"/><line x1="384.5" x2="384.5" y2="768" stroke="%23EAECF0"/><line x1="432.5" x2="432.5" y2="768" stroke="%23EAECF0"/><line x1="480.5" x2="480.5" y2="768" stroke="%23EAECF0"/><line x1="528.5" x2="528.5" y2="768" stroke="%23EAECF0"/><line x1="576.5" x2="576.5" y2="768" stroke="%23EAECF0"/><line x1="624.5" x2="624.5" y2="768" stroke="%23EAECF0"/><line x1="672.5" x2="672.5" y2="768" stroke="%23EAECF0"/><line x1="720.5" x2="720.5" y2="768" stroke="%23EAECF0"/></g><rect x="0.5" y="0.5" width="767" height="767" stroke="%23EAECF0"/><g clip-path="url(%23clip2_52_53336)"><line y1="47.5" x2="768" y2="47.5" stroke="%23EAECF0"/><line y1="95.5" x2="768" y2="95.5" stroke="%23EAECF0"/><line y1="143.5" x2="768" y2="143.5" stroke="%23EAECF0"/><line y1="191.5" x2="768" y2="191.5" stroke="%23EAECF0"/><line y1="239.5" x2="768" y2="239.5" stroke="%23EAECF0"/><line y1="287.5" x2="768" y2="287.5" stroke="%23EAECF0"/><line y1="335.5" x2="768" y2="335.5" stroke="%23EAECF0"/><line y1="383.5" x2="768" y2="383.5" stroke="%23EAECF0"/><line y1="431.5" x2="768" y2="431.5" stroke="%23EAECF0"/><line y1="479.5" x2="768" y2="479.5" stroke="%23EAECF0"/><line y1="527.5" x2="768" y2="527.5" stroke="%23EAECF0"/><line y1="575.5" x2="768" y2="575.5" stroke="%23EAECF0"/><line y1="623.5" x2="768" y2="623.5" stroke="%23EAECF0"/><line y1="671.5" x2="768" y2="671.5" stroke="%23EAECF0"/><line y1="719.5" x2="768" y2="719.5" stroke="%23EAECF0"/><line y1="767.5" x2="768" y2="767.5" stroke="%23EAECF0"/></g><rect x="0.5" y="0.5" width="767" height="767" stroke="%23EAECF0"/></g></g><defs><radialGradient id="paint0_radial_52_53336" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(384 384) rotate(90) scale(384 384)"><stop/><stop offset="1" stop-opacity="0"/></radialGradient><clipPath id="clip0_52_53336"><rect width="768" height="768" fill="white"/></clipPath><clipPath id="clip1_52_53336"><rect width="768" height="768" fill="white"/></clipPath><clipPath id="clip2_52_53336"><rect width="768" height="768" fill="white"/></clipPath></defs></svg>');
   background-position: center -350px;
 }
@@ -36,8 +36,8 @@
 .form-group label {
   display: block;
   margin-bottom: 5px;
-  font-size: 13px;
-  color: var(--main-text-color); 
+  font-size: var(--font-regular);
+  color: var(--main-text-color);
   font-weight: 500;
 }
 
@@ -49,25 +49,26 @@
   padding: 8px 12px;
   border: 1px solid #D0D5DD;
   border-radius: 8px;
-  font-size: 13px;
+  font-size: var(--font-regular);
   box-sizing: border-box;
-  color: var(--second-text-color); 
+  color: var(--second-text-color);
+
   ::placeholder {
-    color: var(--second-text-color); 
+    color: var(--second-text-color);
   }
 }
 
 .form-group input[type="checkbox"],
 .form-group a {
-  font-size: 13px;
-  color: var(--main-purple); 
+  font-size: var(--font-regular);
+  color: var(--main-purple);
   text-decoration: none;
   font-weight: bold;
   margin-right: 5px;
 }
 
 .create-account-button,
-.sign-in-button{
+.sign-in-button {
   width: 100%;
   padding: 10px;
   margin-bottom: 15px;
@@ -75,13 +76,13 @@
   border-radius: 8px;
   color: #fff;
   cursor: pointer;
-  font-size: 13px;
-  background-color: var(--main-purple); 
+  font-size: var(--font-regular);
+  background-color: var(--main-purple);
 }
 
 .sign-up-link {
   text-align: center;
-  font-size: 13px;
+  font-size: var(--font-regular);
   font-weight: 450;
   color: var(--second-text-color);
 }
@@ -105,32 +106,33 @@
 
 /* For Create an Account Page */
 .password-constraints {
-  font-size: 13px;
+  font-size: var(--font-regular);
   display: flex;
   align-items: center;
   color: var(--second-text-color);
   margin-bottom: 7px;
 }
+
 .password-constraints .MuiSvgIcon-root {
-  color: var(--main-text-color); 
+  color: var(--main-text-color);
 }
 
-.create-account-button{
+.create-account-button {
   margin-top: 20px;
 }
 
-.check-div{
+.check-div {
   display: flex;
   margin-bottom: 0.25rem;
 }
 
-.login-container h3{
+.login-container h3 {
   /* font-size: 16px; */
   color: var(--second-text-color);
   text-align: center;
   /* font-weight: 500; */
   margin-bottom: 30px;
-  font-size: 13px;
+  font-size: var(--font-regular);
   font-weight: 400;
   line-height: 24px;
 }
@@ -144,7 +146,7 @@
   margin-top: 5px;
   color: var(--second-text-color);
   cursor: pointer;
-  font-size: 13px;
+  font-size: var(--font-regular);
   background-color: transparent;
   border: none;
   outline: none;
@@ -154,10 +156,10 @@
   justify-content: center;
 }
 
-.error-message{
+.error-message {
   color: #D92D20;
-  font-size: 13px;
-  font-weight: 400;  
+  font-size: var(--font-regular);
+  font-weight: 400;
   margin-bottom: 1rem;
   margin-top: 0.25rem;
 }

--- a/frontend/src/styles/globals.scss
+++ b/frontend/src/styles/globals.scss
@@ -8,10 +8,10 @@ $base-font-size: 16px;
     font-size: 16px;
     line-height: 24px;
   } @else if $type == informative {
-    font-size: 11px;
+    font-size: var(--font-informative);
     line-height: 11px;
   } @else {
-    font-size: 13px;
+    font-size: var(--font-regular);
     line-height: 13px;
   }
 

--- a/frontend/src/styles/variables.css
+++ b/frontend/src/styles/variables.css
@@ -1,62 +1,67 @@
 :root {
-    --main-text-color: #344054;
-    --second-text-color: #667085;
-    --third-text-color: #475467;
-    --main-purple: #7f56d9;
-    --light-purple: #f3e5f5;
-    --light-gray: #EAECF0;
-    --light-border-color: #D0D5DD;
-    --border-error-solid: #D92D20;
-    --checkIcon-green: #079455;
-    --background-color: #fcfcfd;
-    --dark-purple: #6941C6;
-    --light-purple-background: #F9F5FF;
-    --grey-border: #EBEBEB;
-    --shadow-one: #10182808;
-    --shadow-two: #10182814;
-    --header-background: #F8F9F8;
-  
-    /* Additional colors */
-    --primary-color: #6200ea;
-    --secondary-color: #03dac6;
-    --error-color: #b00020;
-    --warning-color: #ff9800;
-    --info-color: #2196f3;
-    --success-color: #4caf50;
-    --light-background: #ffffff;
-    --dark-background: #121212;
-    --light-surface: #f5f5f5;
-    --dark-surface: #1e1e1e;
-  
-    /* Custom label tag component */
-    --label-orange-bg: #fff3e0;
-    --label-orange-color: #ef6c00;
-    --label-orange-border: #ef6c00;
-    --label-green-bg: #e8f5e9;
-    --label-green-border: #a5d6a7;
-    --label-new-dot: #ff9800;
-  }
-  
-  /* Dark mode overrides */
-  body[data-theme='dark'] {
-    --main-text-color: #FFFFFF;
-    --second-text-color: #B0B0B0;
-    --third-text-color: #A0A0A0;
-    --background-color: #121212;
-    --header-background: #1F1F1F;
-    --main-purple: #bb86fc;
-    --light-purple: #3a3a3a;
-    --light-gray: #2c2c2c;
-    --light-border-color: #444444;
-    --primary-color: #bb86fc;
-    --secondary-color: #03dac6;
-    --error-color: #cf6679;
-    --warning-color: #ffb74d;
-    --info-color: #64b5f6;
-    --success-color: #81c784;
-    --light-background: #1e1e1e;
-    --dark-background: #121212;
-    --light-surface: #2c2c2c;
-    --dark-surface: #1e1e1e;
-  }
-  
+  --main-text-color: #344054;
+  --second-text-color: #667085;
+  --third-text-color: #475467;
+  --main-purple: #7f56d9;
+  --light-purple: #f3e5f5;
+  --light-gray: #EAECF0;
+  --light-border-color: #D0D5DD;
+  --border-error-solid: #D92D20;
+  --checkIcon-green: #079455;
+  --background-color: #fcfcfd;
+  --dark-purple: #6941C6;
+  --light-purple-background: #F9F5FF;
+  --grey-border: #EBEBEB;
+  --shadow-one: #10182808;
+  --shadow-two: #10182814;
+  --header-background: #F8F9F8;
+
+  /* Font size variables */
+  --font-regular: 13px;
+  /* For standard text size */
+  --font-informative: 11px;
+  /* For smaller, informative text */
+
+  /* Additional colors */
+  --primary-color: #6200ea;
+  --secondary-color: #03dac6;
+  --error-color: #b00020;
+  --warning-color: #ff9800;
+  --info-color: #2196f3;
+  --success-color: #4caf50;
+  --light-background: #ffffff;
+  --dark-background: #121212;
+  --light-surface: #f5f5f5;
+  --dark-surface: #1e1e1e;
+
+  /* Custom label tag component */
+  --label-orange-bg: #fff3e0;
+  --label-orange-color: #ef6c00;
+  --label-orange-border: #ef6c00;
+  --label-green-bg: #e8f5e9;
+  --label-green-border: #a5d6a7;
+  --label-new-dot: #ff9800;
+}
+
+/* Dark mode overrides */
+body[data-theme='dark'] {
+  --main-text-color: #FFFFFF;
+  --second-text-color: #B0B0B0;
+  --third-text-color: #A0A0A0;
+  --background-color: #121212;
+  --header-background: #1F1F1F;
+  --main-purple: #bb86fc;
+  --light-purple: #3a3a3a;
+  --light-gray: #2c2c2c;
+  --light-border-color: #444444;
+  --primary-color: #bb86fc;
+  --secondary-color: #03dac6;
+  --error-color: #cf6679;
+  --warning-color: #ffb74d;
+  --info-color: #64b5f6;
+  --success-color: #81c784;
+  --light-background: #1e1e1e;
+  --dark-background: #121212;
+  --light-surface: #2c2c2c;
+  --dark-surface: #1e1e1e;
+}

--- a/frontend/src/templates/GuideMainPageTemplate/GuideMainPageTemplate.css
+++ b/frontend/src/templates/GuideMainPageTemplate/GuideMainPageTemplate.css
@@ -38,7 +38,7 @@
 .tour-info-container p {
   margin-bottom: 0;
   color: #6b7280;
-  font-size: 13px;
+  font-size: var(--font-regular);
   font-weight: 400;
   line-height: 20px;
   text-align: left;


### PR DESCRIPTION
### Summary
This PR refactors all instances of `font-size: 13px` and `font-size: 11px` to use CSS variables. Specifically, I replaced:
- `font-size: 13px` with `var(--font-regular)`
- `font-size: 11px` with `var(--font-informative)`

### Changes
- Updated font sizes across the application to use variables from `styles/variables.css`.
- Ensured consistency in font sizes and verified that nothing is broken.

### Issue Reference
This fixes issue #289.

### Testing
I tested the application locally and ensured that the updated font sizes work as expected without breaking any elements.
<img width="959" alt="#289" src="https://github.com/user-attachments/assets/9aeb5947-542c-4639-9cb3-ed03f9d48456">
