### PR TITLE
Updating seeders with user enum values

### DIFF
--- a/backend/seeders/20240610054534-demo-users.js
+++ b/backend/seeders/20240610054534-demo-users.js
@@ -1,5 +1,8 @@
 "use strict";
 
+const constants = require("../src/utils/constants");
+const userRole = constants.ROLE;
+
 module.exports = {
   up: async (queryInterface, Sequelize) => {
     const hashedPassword = "$2b$10$tQiyc0NpG9UFoH6k6j6IbuPcZNFZFUkFMC28r9752WLqlDB.sIzC." //password123
@@ -10,28 +13,28 @@ module.exports = {
           name: "demoUser1",
           email: "demo1@example.com",
           password: hashedPassword,
-          role: "user",
+          role: userRole.MEMBER,
           createdAt: new Date(),
         },
         {
           name: "demoUser2",
           email: "demo2@example.com",
           password: hashedPassword,
-          role: "user",
+          role: userRole.MEMBER,
           createdAt: new Date(),
         },
         {
           name: "demoUser3",
           email: "demo3@example.com",
           password: hashedPassword,
-          role: "user",
+          role: userRole.MEMBER,
           createdAt: new Date(),
         },
         {
           name: "demoUser4",
           email: "demo4@example.com",
           password: hashedPassword,
-          role: "user",
+          role: userRole.MEMBER,
           createdAt: new Date(),
         },
       ],


### PR DESCRIPTION
The previous seeders were using the string values for the `role` field of the `users` table, which was creating error on running seeders. I have updated the `role` field to use the new enum values.