### PR TITLE
Add Vite alias for components

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,7 +6,7 @@ import PasswordResetPage from "./scenes/login/PassswordResetPage";
 import ForgotPasswordPage from "./scenes/login/ForgotPasswordPage";
 import CheckYourEmailPage from "./scenes/login/CheckYourEmailPage";
 import SetNewPasswordPage from "./scenes/login/SetNewPassword";
-import Private from "./components/Private";
+import Private from "@components/Private";
 import ProgressStepsMain from "./scenes/progressSteps/ProgressStepsMain";
 import Settings from "./scenes/settings/Settings";
 import BannerPage from "./scenes/banner/CreateBannerPage";

--- a/frontend/src/index.jsx
+++ b/frontend/src/index.jsx
@@ -6,7 +6,7 @@ import { BrowserRouter as Router} from "react-router-dom";
 import { lightTheme } from "./assets/theme";
 import { ThemeProvider } from "@mui/material";
 import { AuthProvider } from "./services/authProvider.jsx";
-import Toast from "./components/Toast/Toast.jsx";
+import Toast from "@components/Toast/Toast.jsx";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>

--- a/frontend/src/products/Popup/PopupComponent.jsx
+++ b/frontend/src/products/Popup/PopupComponent.jsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import DOMPurify from "dompurify";
 import styles from "./PopupComponent.module.css"; // Use your module CSS file
 import CloseOutlinedIcon from '@mui/icons-material/CloseOutlined';
-import Button from "../../components/Button/Button";
+import Button from "@components/Button/Button";
 
 const PopupComponent = ({
   header,

--- a/frontend/src/scenes/banner/BannerPageComponents/BannerLeftAppearance/BannerLeftApperance.jsx
+++ b/frontend/src/scenes/banner/BannerPageComponents/BannerLeftAppearance/BannerLeftApperance.jsx
@@ -1,6 +1,6 @@
 import { React } from 'react';
 import styles from './BannerLeftApperance.module.scss';
-import ColorTextField from '../../../../components/ColorTextField/ColorTextField';
+import ColorTextField from '@components/ColorTextField/ColorTextField';
 
 const BannerLeftAppearance = ({ backgroundColor, setBackgroundColor, fontColor, setFontColor }) => {
 

--- a/frontend/src/scenes/banner/BannerPageComponents/BannerLeftContent/BannerLeftContent.jsx
+++ b/frontend/src/scenes/banner/BannerPageComponents/BannerLeftContent/BannerLeftContent.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import styles from './BannerLeftContent.module.scss';
-import DropdownList from '../../../../components/DropdownList/DropdownList';
-import CustomTextField from '../../../../components/TextFieldComponents/CustomTextField/CustomTextField';
-import RadioButton from '../../../../components/RadioButton/RadioButton';
+import DropdownList from '@components/DropdownList/DropdownList';
+import CustomTextField from '@components/TextFieldComponents/CustomTextField/CustomTextField';
+import RadioButton from '@components/RadioButton/RadioButton';
 
 const BannerLeftContent = ({ setIsTopPosition, url, setUrl, setButtonAction, isTopPosition, buttonAction }) => {
     const handleSetUrl = (event) => {

--- a/frontend/src/scenes/errors/Error.jsx
+++ b/frontend/src/scenes/errors/Error.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from "prop-types";
 import styles from './Error.module.scss';
-import Button from '../../components/Button/Button';
+import Button from '@components/Button/Button';
 
 export const ErrorComponent = ({ text, errorAction }) => {
   const errorButtonStyle = {

--- a/frontend/src/scenes/hints/CreateHintPage.jsx
+++ b/frontend/src/scenes/hints/CreateHintPage.jsx
@@ -1,8 +1,8 @@
 import React, { useState } from "react";
 import GuideTemplate from "../../templates/GuideTemplate/GuideTemplate";
-import RichTextEditor from "../../components/RichTextEditor/RichTextEditor";
-import HintLeftContent from "../../components/HintPageComponents/HintLeftContent/HintLeftContent";
-import HintLeftAppearance from "../../components/HintPageComponents/HintLeftAppearance/HintLeftAppearance";
+import RichTextEditor from "@components/RichTextEditor/RichTextEditor";
+import HintLeftContent from "@components/HintPageComponents/HintLeftContent/HintLeftContent";
+import HintLeftAppearance from "@components/HintPageComponents/HintLeftAppearance/HintLeftAppearance";
 
 const HintPage = () => {
   const [activeButton, setActiveButton] = useState(0);

--- a/frontend/src/scenes/links/LinksDefaultPage.jsx
+++ b/frontend/src/scenes/links/LinksDefaultPage.jsx
@@ -1,6 +1,6 @@
-import CreateActivityButton from "../../components/Button/CreateActivityButton/CreateActivityButton"
+import CreateActivityButton from "@components/Button/CreateActivityButton/CreateActivityButton"
 import { ACTIVITY_TYPES } from "../../data/createActivityButtonData";
-import ParagraphCSS from "../../components/ParagraphCSS/ParagraphCSS";
+import ParagraphCSS from "@components/ParagraphCSS/ParagraphCSS";
 
 const LinksDefaultPage = () => {
     const style = {

--- a/frontend/src/scenes/login/CheckYourEmailPage.jsx
+++ b/frontend/src/scenes/login/CheckYourEmailPage.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styles from './Login.module.css';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import { useLocation, useNavigate } from 'react-router-dom';
-import CustomLink from '../../components/CustomLink/CustomLink';
+import CustomLink from '@components/CustomLink/CustomLink';
 
 const CheckYourEmailPage = () => {
   const navigate = useNavigate();

--- a/frontend/src/scenes/login/CreateAccountPage.jsx
+++ b/frontend/src/scenes/login/CreateAccountPage.jsx
@@ -1,14 +1,14 @@
 import React, { useState } from 'react';
 import styles from './Login.module.css'; 
-import CustomTextField from '../../components/TextFieldComponents/CustomTextField/CustomTextField';
+import CustomTextField from '@components/TextFieldComponents/CustomTextField/CustomTextField';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import CircularProgress from '@mui/material/CircularProgress';
 import { signUp } from '../../services/loginServices';
-import CustomLink from '../../components/CustomLink/CustomLink';
+import CustomLink from '@components/CustomLink/CustomLink';
 import { handleAuthSuccess } from '../../utils/loginHelper';
 import { useAuth } from '../../services/authProvider';
 import { useNavigate } from 'react-router-dom';
-import Logo from '../../components/Logo/Logo';
+import Logo from '@components/Logo/Logo';
 
 function CreateAccountPage() {
   const [formData, setFormData] = useState({ name: '', surname: '', email: '', password: '' });

--- a/frontend/src/scenes/login/ForgotPasswordPage.jsx
+++ b/frontend/src/scenes/login/ForgotPasswordPage.jsx
@@ -3,9 +3,9 @@ import styles from './Login.module.css';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import { forgotPassword } from '../../services/loginServices'; // Make sure this function is properly implemented
 import { useNavigate } from 'react-router-dom';
-import CustomTextField from '../../components/TextFieldComponents/CustomTextField/CustomTextField';
+import CustomTextField from '@components/TextFieldComponents/CustomTextField/CustomTextField';
 import CircularProgress from '@mui/material/CircularProgress';
-import Logo from '../../components/Logo/Logo';
+import Logo from '@components/Logo/Logo';
 
 const ForgotPasswordPage = () => {
   const navigate = useNavigate();

--- a/frontend/src/scenes/login/LoginPage.jsx
+++ b/frontend/src/scenes/login/LoginPage.jsx
@@ -1,13 +1,13 @@
 import React, { useState } from 'react';
 import styles from './Login.module.css';
-import CustomTextField from '../../components/TextFieldComponents/CustomTextField/CustomTextField';
+import CustomTextField from '@components/TextFieldComponents/CustomTextField/CustomTextField';
 import CircularProgress from '@mui/material/CircularProgress';
 import { login } from '../../services/loginServices';
-import CustomLink from '../../components/CustomLink/CustomLink';
+import CustomLink from '@components/CustomLink/CustomLink';
 import { handleAuthSuccess } from '../../utils/loginHelper';
 import { useAuth } from '../../services/authProvider';
 import { useNavigate } from 'react-router-dom';
-import Logo from '../../components/Logo/Logo';
+import Logo from '@components/Logo/Logo';
 
 function LoginPage() {
   const [email, setEmail] = useState('');

--- a/frontend/src/scenes/login/SetNewPassword.jsx
+++ b/frontend/src/scenes/login/SetNewPassword.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import styles from './Login.module.css';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
-import CustomTextField from '../../components/TextFieldComponents/CustomTextField/CustomTextField';
+import CustomTextField from '@components/TextFieldComponents/CustomTextField/CustomTextField';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import CircularProgress from '@mui/material/CircularProgress';
 import { resetPassword } from '../../services/loginServices';

--- a/frontend/src/scenes/popup/CreatePopupPage.jsx
+++ b/frontend/src/scenes/popup/CreatePopupPage.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import GuideTemplate from '../../templates/GuideTemplate/GuideTemplate';
-import RichTextEditor from '../../components/RichTextEditor/RichTextEditor';
+import RichTextEditor from '@components/RichTextEditor/RichTextEditor';
 import PopupAppearance from './PopupPageComponents/PopupAppearance/PopupAppearance';
 import PopupContent from './PopupPageComponents/PopupContent/PopupContent';
 import { addPopup, getPopupById, editPopup } from '../../services/popupServices';

--- a/frontend/src/scenes/popup/PopupPageComponents/PopupAppearance/PopupAppearance.jsx
+++ b/frontend/src/scenes/popup/PopupPageComponents/PopupAppearance/PopupAppearance.jsx
@@ -1,7 +1,7 @@
 import { React } from 'react';
 import styles from './PopupAppearance.module.scss';
-import ColorTextField from '../../../../components/ColorTextField/ColorTextField';
-import DropdownList from '../../../../components/DropdownList/DropdownList';
+import ColorTextField from '@components/ColorTextField/ColorTextField';
+import DropdownList from '@components/DropdownList/DropdownList';
 
 const PopupAppearance = ({ data = [], setPopupSize, popupSize }) => {
     const handleActionChange = (newAction) => {

--- a/frontend/src/scenes/popup/PopupPageComponents/PopupContent/PopupContent.jsx
+++ b/frontend/src/scenes/popup/PopupPageComponents/PopupContent/PopupContent.jsx
@@ -1,7 +1,7 @@
 import { React } from 'react';
 import styles from './PopupContent.module.scss';
-import DropdownList from '../../../../components/DropdownList/DropdownList';
-import CustomTextField from '../../../../components/TextFieldComponents/CustomTextField/CustomTextField';
+import DropdownList from '@components/DropdownList/DropdownList';
+import CustomTextField from '@components/TextFieldComponents/CustomTextField/CustomTextField';
 
 const PopupContent = ({ actionButtonText, setActionButtonText, setActionButtonUrl, buttonAction, actionButtonUrl, setButtonAction }) => {
     const handleActionButtonText = (event) => {

--- a/frontend/src/scenes/progressSteps/ProgressStepsMain.jsx
+++ b/frontend/src/scenes/progressSteps/ProgressStepsMain.jsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 import ProgressSteps from './ProgressSteps/ProgressSteps';
 import styles from './ProgressStepsMain.module.scss';
-import Button from '../../components/Button/Button';
-import CheckboxHRM from '../../components/Checkbox/CheckboxHRM';
+import Button from '@components/Button/Button';
+import CheckboxHRM from '@components/Checkbox/CheckboxHRM';
 import TeamMembersList from './ProgressSteps/TeamMemberList/TeamMembersList';
 import { useNavigate } from "react-router-dom";
 

--- a/frontend/src/scenes/settings/Modals/ChangeMemberRoleModal/ChangeMemberRoleModal.jsx
+++ b/frontend/src/scenes/settings/Modals/ChangeMemberRoleModal/ChangeMemberRoleModal.jsx
@@ -2,7 +2,7 @@ import { React } from 'react';
 import PropTypes from 'prop-types';
 import Modal from '@mui/material/Modal';
 import Box from '@mui/material/Box';
-import Button from '../../../../components/Button/Button';
+import Button from '@components/Button/Button';
 import styles from './ChangeMemberRoleModal.module.scss';
 
 const ChangeMemberRoleModal = ({ open, setModalOpen, selectedMember, handleChangeRole }) => {

--- a/frontend/src/scenes/settings/Modals/DeleteConfirmationModal/DeleteConfirmationModal.jsx
+++ b/frontend/src/scenes/settings/Modals/DeleteConfirmationModal/DeleteConfirmationModal.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Modal from '@mui/material/Modal';
 import Box from '@mui/material/Box';
-import Button from '../../../../components/Button/Button';
+import Button from '@components/Button/Button';
 import styles from './DeleteConfirmationModal.module.scss';
 
 const DeleteConfirmationModal = ({ open, handleClose, handleDelete }) => {

--- a/frontend/src/scenes/settings/Modals/InviteTeamMemberModal/InviteTeamMemberModal.jsx
+++ b/frontend/src/scenes/settings/Modals/InviteTeamMemberModal/InviteTeamMemberModal.jsx
@@ -2,10 +2,10 @@ import { React, useState } from 'react';
 import PropTypes from 'prop-types';
 import Modal from '@mui/material/Modal';
 import Box from '@mui/material/Box';
-import Button from '../../../../components/Button/Button';
+import Button from '@components/Button/Button';
 import styles from './InviteTeamMemberModal.module.scss';
-import CustomTextField from '../../../../components/TextFieldComponents/CustomTextField/CustomTextField';
-import DropdownList from '../../../../components/DropdownList/DropdownList';
+import CustomTextField from '@components/TextFieldComponents/CustomTextField/CustomTextField';
+import DropdownList from '@components/DropdownList/DropdownList';
 import { roles } from '../../../../utils/constants';
 
 const InviteTeamMemberModal = ({ open, handleClose, handleInviteTeamMember }) => {

--- a/frontend/src/scenes/settings/Modals/RemoveTeamMemberModal/RemoveTeamMemberModal.jsx
+++ b/frontend/src/scenes/settings/Modals/RemoveTeamMemberModal/RemoveTeamMemberModal.jsx
@@ -2,7 +2,7 @@ import { React } from 'react';
 import PropTypes from 'prop-types';
 import Modal from '@mui/material/Modal';
 import Box from '@mui/material/Box';
-import Button from '../../../../components/Button/Button';
+import Button from '@components/Button/Button';
 import styles from './RemoveTeamMemberModal.module.scss';
 
 const RemoveTeamMemberModal = ({ open, setModalOpen, selectedMember, handleRemoveTeamMember }) => {

--- a/frontend/src/scenes/settings/Modals/UploadImageModal/UploadModal.jsx
+++ b/frontend/src/scenes/settings/Modals/UploadImageModal/UploadModal.jsx
@@ -1,7 +1,7 @@
 import { React, useState, useCallback } from 'react';
 import Modal from '@mui/material/Modal';
 import Box from '@mui/material/Box';
-import Button from '../../../../components/Button/Button';
+import Button from '@components/Button/Button';
 import styles from './UploadModal.module.scss';
 import { useDropzone } from 'react-dropzone';
 import CloudUploadOutlinedIcon from '@mui/icons-material/CloudUploadOutlined';

--- a/frontend/src/scenes/settings/PasswordTab/PasswordTab.jsx
+++ b/frontend/src/scenes/settings/PasswordTab/PasswordTab.jsx
@@ -1,8 +1,8 @@
 import React, { useState } from "react";
 import { LuAlertTriangle } from "react-icons/lu";
 import styles from "./PasswordTab.module.css";
-import CustomTextField from "../../../components/TextFieldComponents/CustomTextField/CustomTextField";
-import Button from "../../../components/Button/Button";
+import CustomTextField from "@components/TextFieldComponents/CustomTextField/CustomTextField";
+import Button from "@components/Button/Button";
 
 const PasswordTab = () => {
   const [currentPassword, setCurrentPassword] = useState('');

--- a/frontend/src/scenes/settings/ProfileTab/ProfileTab.jsx
+++ b/frontend/src/scenes/settings/ProfileTab/ProfileTab.jsx
@@ -1,8 +1,8 @@
 import React, { useState } from "react";
-import Avatar from "../../../components/Avatar/Avatar";
+import Avatar from "@components/Avatar/Avatar";
 import styles from "./ProfileTab.module.css";
-import CustomTextField from "../../../components/TextFieldComponents/CustomTextField/CustomTextField";
-import Button from "../../../components/Button/Button";
+import CustomTextField from "@components/TextFieldComponents/CustomTextField/CustomTextField";
+import Button from "@components/Button/Button";
 import { useAuth } from "../../../services/authProvider";
 import DeleteConfirmationModal from "../Modals/DeleteConfirmationModal/DeleteConfirmationModal";
 import { deleteAccount, updateUser } from "../../../services/settingServices";

--- a/frontend/src/scenes/settings/TeamTab/TeamTab.jsx
+++ b/frontend/src/scenes/settings/TeamTab/TeamTab.jsx
@@ -9,9 +9,9 @@ import { VscEdit } from "react-icons/vsc";
 
 import styles from './TeamTab.module.css';
 import TeamTable from "./TeamTable/TeamTable";
-import Button from "../../../components/Button/Button";
-import CustomTextField from "../../../components/TextFieldComponents/CustomTextField/CustomTextField";
-import LoadingArea from "../../../components/LoadingPage/LoadingArea";
+import Button from "@components/Button/Button";
+import CustomTextField from "@components/TextFieldComponents/CustomTextField/CustomTextField";
+import LoadingArea from "@components/LoadingPage/LoadingArea";
 
 import { handleChangeRoleSuccess, handleEditOrgNameSuccess, handleGenericError, handleInviteMemberSuccess, handleRemoveTeamMemberSuccess } from "../../../utils/settingsHelper";
 import { changeMemberRole, getOrgDetails, inviteMember, removeTeamMember, updateTeamDetails } from "../../../services/settingServices";

--- a/frontend/src/scenes/settings/TeamTab/TeamTable/TeamTable.jsx
+++ b/frontend/src/scenes/settings/TeamTab/TeamTable/TeamTable.jsx
@@ -9,7 +9,7 @@ import Paper from '@mui/material/Paper';
 import styles from './TeamTable.module.css';
 import { RiDeleteBinLine } from "react-icons/ri";
 import { useAuth } from '../../../../services/authProvider';
-import DropdownMenu from '../../../../components/DropdownMenu/DropdownMenu';
+import DropdownMenu from '@components/DropdownMenu/DropdownMenu';
 import { roles } from '../../../../utils/constants';
 
 export default function TeamTable({ team, setRemoveModalOpen, setChangeRoleModalOpen, setSelectedMember }) {

--- a/frontend/src/scenes/tours/CreateToursPopup/CreateToursPopup.jsx
+++ b/frontend/src/scenes/tours/CreateToursPopup/CreateToursPopup.jsx
@@ -1,9 +1,9 @@
 import { useState, React } from 'react';
 import styles from './CreateToursPopup.module.scss';
-import Switch from '../../../components/Switch/Switch'
+import Switch from '@components/Switch/Switch'
 import CloseOutlinedIcon from '@mui/icons-material/CloseOutlined';
-import DropdownList from '../../../components/DropdownList/DropdownList';
-import CustomTextField from '../../../components/TextFieldComponents/CustomTextField/CustomTextField'
+import DropdownList from '@components/DropdownList/DropdownList';
+import CustomTextField from '@components/TextFieldComponents/CustomTextField/CustomTextField'
 
 const CreateToursPopup = ({ onClose }) => {
 

--- a/frontend/src/scenes/tours/ProductTour.jsx
+++ b/frontend/src/scenes/tours/ProductTour.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import List from '../../templates/GuideMainPageTemplate/GuideMainPageComponents/List/List';
 import ContentArea from '../../templates/GuideMainPageTemplate/GuideMainPageComponents/ContentArea/ContentArea';
 import ConfirmationPopup from '../../templates/GuideMainPageTemplate/GuideMainPageComponents/ConfirmationPopup/ConfirmationPopup';
-import Button from '../../components/Button/Button';
+import Button from '@components/Button/Button';
 import './ProductTourStyles.css';
 import CreateToursPopup from './CreateToursPopup/CreateToursPopup';
 

--- a/frontend/src/scenes/tours/ToursDefaultPage.jsx
+++ b/frontend/src/scenes/tours/ToursDefaultPage.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
-import CreateActivityButton from "../../components/Button/CreateActivityButton/CreateActivityButton";
+import CreateActivityButton from "@components/Button/CreateActivityButton/CreateActivityButton";
 import { ACTIVITY_TYPES } from "../../data/createActivityButtonData";
-import ParagraphCSS from "../../components/ParagraphCSS/ParagraphCSS";
+import ParagraphCSS from "@components/ParagraphCSS/ParagraphCSS";
 import TourPage from './ProductTour';
 
 const ToursDefaultPage = () => {

--- a/frontend/src/templates/DefaultPageTemplate/DefaultPageTemplate.jsx
+++ b/frontend/src/templates/DefaultPageTemplate/DefaultPageTemplate.jsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import PropTypes from 'prop-types';
-import ParagraphCSS from '../../components/ParagraphCSS/ParagraphCSS';
+import ParagraphCSS from '@components/ParagraphCSS/ParagraphCSS';
 import GuideMainPageTemplate from '../GuideMainPageTemplate/GuideMainPageTemplate';
-import CreateActivityButton from '../../components/Button/CreateActivityButton/CreateActivityButton';
+import CreateActivityButton from '@components/Button/CreateActivityButton/CreateActivityButton';
 import toastEmitter, { TOAST_EMITTER_KEY } from '../../utils/toastEmitter';
 import './DefaultPageTemplate.css'
 

--- a/frontend/src/templates/GuideMainPageTemplate/GuideMainPageTemplate.jsx
+++ b/frontend/src/templates/GuideMainPageTemplate/GuideMainPageTemplate.jsx
@@ -3,7 +3,7 @@ import List from './GuideMainPageComponents/List/List';
 import ContentArea from './GuideMainPageComponents/ContentArea/ContentArea';
 import ContentHeader from './GuideMainPageComponents/ContentHeader/ContentHeader';
 import ConfirmationPopup from './GuideMainPageComponents/ConfirmationPopup/ConfirmationPopup';
-import Button from '../../components/Button/Button';
+import Button from '@components/Button/Button';
 import './GuideMainPageTemplate.css';
 import { activityInfoData } from '../../data/guideMainPageData';
 

--- a/frontend/src/templates/GuideTemplate/GuideTemplate.jsx
+++ b/frontend/src/templates/GuideTemplate/GuideTemplate.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import CloseOutlinedIcon from '@mui/icons-material/CloseOutlined';
 import styles from './GuideTemplate.module.scss';
 import classNames from 'classnames';
-import Button from '../../components/Button/Button';
+import Button from '@components/Button/Button';
 import { useNavigate } from 'react-router-dom';
 
 const GuideTemplate = ({ title = '', handleButtonClick = () => null, activeButton = 0, leftContent = () => null, rightContent = () => null, leftAppearance = () => null, onSave= () => null, contentType = "/" }) => {

--- a/frontend/src/templates/HomePageTemplate/HomePageTemplate.jsx
+++ b/frontend/src/templates/HomePageTemplate/HomePageTemplate.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import LeftMenu from "../../components/LeftMenu/LeftMenu";
+import LeftMenu from "@components/LeftMenu/LeftMenu";
 import "./HomePageTemplate.css";
 import { Outlet } from "react-router-dom";
 

--- a/frontend/src/tests/components/Button/Button.test.jsx
+++ b/frontend/src/tests/components/Button/Button.test.jsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
-import Button from '../../../components/Button/Button';
+import Button from '@components/Button/Button';
 
 describe('Button component', () => {
   it('renders with default props', () => {

--- a/frontend/src/tests/components/CustomLabelTag/CustomLabelTag.test.jsx
+++ b/frontend/src/tests/components/CustomLabelTag/CustomLabelTag.test.jsx
@@ -1,7 +1,7 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import { render } from '@testing-library/react';
-import CustomLabelTag from '../../../components/CustomLabelTag/CustomLabelTag';
+import CustomLabelTag from '@components/CustomLabelTag/CustomLabelTag';
 
 
 describe('CustomLabelTag', () => {

--- a/frontend/src/tests/components/Toast/Toast.test.jsx
+++ b/frontend/src/tests/components/Toast/Toast.test.jsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, act } from '@testing-library/react';
-import Toast from '../../../components/Toast/Toast';
+import Toast from '@components/Toast/Toast';
 import toastEmitter, { TOAST_EMITTER_KEY } from '../../../utils/toastEmitter';
 
 describe('Toast', () => {

--- a/frontend/src/tests/components/Toast/ToastItem.test.jsx
+++ b/frontend/src/tests/components/Toast/ToastItem.test.jsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, act, fireEvent } from '@testing-library/react';
-import ToastItem from '../../../components/Toast/ToastItem';
+import ToastItem from '@components/Toast/ToastItem';
 
 describe('ToastItem', () => {
   const mockRemoveToast = vi.fn();

--- a/frontend/src/tests/components/customLinkComponent/CustomLink.test.jsx
+++ b/frontend/src/tests/components/customLinkComponent/CustomLink.test.jsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
-import CustomLink from '../../../components/CustomLink/CustomLink';
+import CustomLink from '@components/CustomLink/CustomLink';
 
 describe('CustomLink', () => {
   it('renders CustomLink with text and url', () => {

--- a/frontend/src/tests/components/textFieldComponent/CustomTextField.test.jsx
+++ b/frontend/src/tests/components/textFieldComponent/CustomTextField.test.jsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
-import CustomTextField from '../../../components/TextFieldComponents/CustomTextField/CustomTextField';
+import CustomTextField from '@components/TextFieldComponents/CustomTextField/CustomTextField';
 
 describe('CustomTextField', () => {
   it('renders the CustomTextField with default props', () => {

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -29,5 +29,10 @@ export default defineConfig({
         inline: ['mui-color-input']
       },
     },
+  },
+  resolve: {
+    alias: {
+      '@components': '/src/components'
+    }
   }
 });


### PR DESCRIPTION
Closes #326 

### Add Vite alias for /src/components 
The pull request adds an alias in the Vite configuration to map @ components to the /src/components directory. I have also updated all the imports throughout the frontend to use the new alias.

**Changes**
Updated vite.config.js to include the following alias:
```
resolve: {
  alias: {
    '@components': '/src/components'
  }
}
```