### PR TITLE
Fix #341 : Update CustomTextField for full-width support

### DIFF
--- a/frontend/src/components/TextFieldComponents/CustomTextField/CustomTextField.jsx
+++ b/frontend/src/components/TextFieldComponents/CustomTextField/CustomTextField.jsx
@@ -34,6 +34,8 @@ const CustomTextField = ({
   disabled = false,
   autofocus = false
 }) => {
+  const computedFullWidth = fullWidth || 
+    ["full", "100%", "stretch"].some(value => TextFieldWidth.toLowerCase().includes(value));
   return (
     <div style={style}>
       {!checkCircleIconVisible &&
@@ -57,8 +59,8 @@ const CustomTextField = ({
         onBlur={onBlur}
         required={Boolean(required)}
         className="textField"
-        sx={{ width: fullWidth?"100%": TextFieldWidth }}
-        fullWidth={fullWidth}
+        sx={{ width: computedFullWidth ? "100%" : TextFieldWidth }}
+        fullWidth={computedFullWidth}
         margin={textFieldMargin}
         value={value}
         onChange={onChange}

--- a/frontend/src/components/TextFieldComponents/CustomTextField/CustomTextField.jsx
+++ b/frontend/src/components/TextFieldComponents/CustomTextField/CustomTextField.jsx
@@ -30,6 +30,7 @@ const CustomTextField = ({
   required = false,
   style,
   labelSubText,
+  fullWidth=false, 
   disabled = false,
   autofocus = false
 }) => {
@@ -56,8 +57,8 @@ const CustomTextField = ({
         onBlur={onBlur}
         required={Boolean(required)}
         className="textField"
-        sx={{ width: TextFieldWidth }}
-        fullWidth
+        sx={{ width: fullWidth?"100%": TextFieldWidth }}
+        fullWidth={fullWidth}
         margin={textFieldMargin}
         value={value}
         onChange={onChange}
@@ -118,6 +119,7 @@ CustomTextField.propTypes = {
   displayCheckCircleIcon: PropTypes.bool,
   textFieldMargin: PropTypes.string,
   type: PropTypes.string,
+  fullWidth: PropTypes.bool, 
   required: PropTypes.bool,
 };
 

--- a/frontend/src/components/TextFieldComponents/CustomTextField/CustomTextField.jsx
+++ b/frontend/src/components/TextFieldComponents/CustomTextField/CustomTextField.jsx
@@ -37,7 +37,7 @@ const CustomTextField = ({
   const computedFullWidth = fullWidth || 
     ["full", "100%", "stretch"].some(value => TextFieldWidth.toLowerCase().includes(value));
   return (
-    <div style={style}>
+    <div style={{...style,  ...(computedFullWidth && { width: '100%' })}} >
       {!checkCircleIconVisible &&
         <div>
           <InputLabel sx={{ fontWeight: labelFontWeight, margin: 0 }}>{labelText}</InputLabel>


### PR DESCRIPTION
**Issue:**  
The _CustomTextField_ component does not handle width properly. Specifically, it lacks support for stretching to 100% width.
[#341 ](https://github.com/bluewave-labs/bluewave-onboarding/issues/341)
**Implementation:**  
+ Modified the _CustomTextField.jsx_ file to add a new _fullWidth_ prop as a _boolean_.
+ Replaced the previous _TextFieldWidth_ prop with the new _fullWidth_ prop to manage the width behavior.
+ The _fullWidth_ boolean simplifies the implementation by directly applying a 100% width when set to true, making it more intuitive and easier to use.
