### PR TITLE
fixed issue text editor buttons should be highlighted when selected #415

### DIFF
--- a/frontend/src/components/RichTextEditor/Toolbar/EditorToolbar.jsx
+++ b/frontend/src/components/RichTextEditor/Toolbar/EditorToolbar.jsx
@@ -56,12 +56,18 @@ const Toolbar = ({ editor }) => {
       <Button
         onClick={() => editor.chain().focus().toggleBold().run()}
         disabled={!editor.can().chain().focus().toggleBold().run()}
+        style = {{
+          backgroundColor : editor.isActive("bold") ? "#e0e0e0": "transparent",
+        }}
       >
         <FormatBold />
       </Button>
       <Button
         onClick={() => editor.chain().focus().toggleItalic().run()}
         disabled={!editor.can().chain().focus().toggleItalic().run()}
+        style = {{
+          backgroundColor : editor.isActive("italic")? "#e0e0e0" : "transparent",
+        }}
       >
         <FormatItalic />
       </Button>
@@ -70,6 +76,10 @@ const Toolbar = ({ editor }) => {
         disabled={
           !editor.can().chain().focus().toggleHeading({ level: 2 }).run()
         }
+        style = {{
+          backgroundColor: editor.isActive("heading", {level:3})
+          ? "#e0e0e0" : "transparent",
+        }}
       >
         <Title />
       </Button>
@@ -79,12 +89,20 @@ const Toolbar = ({ editor }) => {
       <Button
         onClick={() => editor.chain().focus().toggleBulletList().run()}
         disabled={!editor.can().chain().focus().toggleBulletList().run()}
+        style = {{
+          backgroundColor : editor.isActive("bulletList") ? "#e0e0e0" : "transparent",
+
+        }}
       >
         <FormatListBulleted />
       </Button>
       <Button
         onClick={() => editor.chain().focus().toggleOrderedList().run()}
         disabled={!editor.can().chain().focus().toggleOrderedList().run()}
+
+        style = {{
+          backgroundColor : editor.isActive("orderedList") ? "#e0e0e0" : "transparent",
+        }}
       >
         <FormatListNumbered />
       </Button>


### PR DESCRIPTION
## Describe your changes

Changes Made:
Added dynamic styling to highlight toolbar buttons (e.g., Bold, Italic) when their formatting is active using editor.isActive().
Refactored Toolbar component to manage button states and styles.
Purpose:
To enhance user experience by visually indicating active formatting in the rich text editor.

Screenshots:
Before:
![1](https://github.com/user-attachments/assets/1f7d8335-d9e8-4e93-b930-d964ce87a60a)

After:
![2](https://github.com/user-attachments/assets/b770b682-d24d-4055-829e-07198b9bfa3f)
![3](https://github.com/user-attachments/assets/22149c29-86f2-4028-b27e-0c7c1a625a4f)



issue number: 415
## Please ensure all items are checked off before requesting a review:

- [ Yes] I deployed the code locally.
- [ Yes] I have performed a self-review of my code.
- [ Yes] I have included the issue # in the PR.
- [ Yes] I have labelled the PR correctly.
- [ Yes] The issue I am working on is assigned to me.
- [ Yes] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [ Yes] I made sure font sizes, color choices etc are all referenced from the theme.
- [ Yes] My PR is granular and targeted to one specific feature.
- [ Yes] I took a screenshot or a video and attached to this PR if there is a UI change.


