### PR TITLE
fix/#367-improved dialog styles on text-editor popup

### DIFF
--- a/frontend/src/components/RichTextEditor/EditorLinkDialog/DialogStyles.js
+++ b/frontend/src/components/RichTextEditor/EditorLinkDialog/DialogStyles.js
@@ -1,7 +1,7 @@
 export const dialogStyles = {
   paper: {
     padding: 2,
-    borderRadius: 4,
+    borderRadius: "4px",
   },
   title: {
     padding: 0,

--- a/frontend/src/components/RichTextEditor/EditorLinkDialog/DialogStyles.js
+++ b/frontend/src/components/RichTextEditor/EditorLinkDialog/DialogStyles.js
@@ -1,0 +1,18 @@
+export const dialogStyles = {
+  paper: {
+    padding: 2,
+    borderRadius: 4,
+  },
+  title: {
+    padding: 0,
+  },
+  content: {
+    padding: 0,
+    paddingBottom: 2,
+    overflow: "hidden",
+  },
+  actions: {
+    paddingBottom: 0,
+    paddingRight: 0,
+  },
+};

--- a/frontend/src/components/RichTextEditor/EditorLinkDialog/LinkDialog.jsx
+++ b/frontend/src/components/RichTextEditor/EditorLinkDialog/LinkDialog.jsx
@@ -7,6 +7,7 @@ import {
 } from "@mui/material";
 import Button from "../../Button/Button";
 import CustomTextField from "../../TextFieldComponents/CustomTextField/CustomTextField";
+import { dialogStyles } from "./DialogStyles";
 
 const LinkDialog = ({
   open,
@@ -18,9 +19,17 @@ const LinkDialog = ({
   handleOpenLink = () => {},
 }) => {
   return (
-    <Dialog open={open} onClose={handleClose}>
-      <DialogTitle>{isLinkActive ? "Edit Link" : "Add Link"}</DialogTitle>
-      <DialogContent>
+    <Dialog
+      PaperProps={{
+        sx: dialogStyles.paper,
+      }}
+      open={open}
+      onClose={handleClose}
+    >
+      <DialogTitle sx={dialogStyles.title}>
+        {isLinkActive ? "Edit Link" : "Add Link"}
+      </DialogTitle>
+      <DialogContent sx={dialogStyles.content}>
         <CustomTextField
           type="url"
           placeholder="https://"
@@ -28,7 +37,7 @@ const LinkDialog = ({
           onChange={(e) => setUrl(e.target.value)}
         />
       </DialogContent>
-      <DialogActions>
+      <DialogActions sx={dialogStyles.actions}>
         {isLinkActive && (
           <Button
             text="Open Link"

--- a/frontend/src/components/RichTextEditor/EditorLinkDialog/LinkDialog.jsx
+++ b/frontend/src/components/RichTextEditor/EditorLinkDialog/LinkDialog.jsx
@@ -27,7 +27,7 @@ const LinkDialog = ({
       onClose={handleClose}
     >
       <DialogTitle sx={dialogStyles.title}>
-        {isLinkActive ? "Edit Link" : "Add Link"}
+        {isLinkActive ? "Edit link" : "Add link"}
       </DialogTitle>
       <DialogContent sx={dialogStyles.content}>
         <CustomTextField
@@ -46,15 +46,16 @@ const LinkDialog = ({
             onClick={handleOpenLink}
           />
         )}
-        <Button
-          text={url ? "Insert/Update" : "Remove Link"}
-          onClick={handleInsertLink}
-        />
+
         <Button
           text="Cancel"
           buttonType="secondary"
           variant="text"
           onClick={handleClose}
+        />
+        <Button
+          text={url ? "Insert/Update" : "Remove link"}
+          onClick={handleInsertLink}
         />
       </DialogActions>
     </Dialog>


### PR DESCRIPTION
## Describe your changes

- Reduced the gap between the title and the field.
- Ensured consistent padding throughout the dialog.
- Border radius
- Moves styles to DialogStyles.js file.

## Issue number

#367 

## Please ensure all items are checked off before requesting a review:

- [ ] I deployed the code locally.
- [ ] I have performed a self-review of my code.
- [ ] I have included the issue # in the PR.
- [ ] I have labelled the PR correctly.
- [ ] The issue I am working on is assigned to me.
- [ ] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [ ] I made sure font sizes, color choices etc are all referenced from the theme.
- [ ] My PR is granular and targeted to one specific feature.
- [ ] I took a screenshot or a video and attached to this PR if there is a UI change.

## Before
![image](https://github.com/user-attachments/assets/222acd97-a6e3-40e8-8628-087d3ae9aba3)

## After

![Screenshot 2024-12-24 022812](https://github.com/user-attachments/assets/e7aef9ae-6866-43ff-8256-a3f60a3585bd)
