### PR TITLE
 Blocked aria-hidden on an element because its descendant retained focus. #422

### DIFF
--- a/frontend/src/templates/GuideMainPageTemplate/GuideMainPageComponents/ConfirmationPopup/ConfirmationPopup.jsx
+++ b/frontend/src/templates/GuideMainPageTemplate/GuideMainPageComponents/ConfirmationPopup/ConfirmationPopup.jsx
@@ -1,17 +1,28 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import { Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, Button } from '@mui/material';
+import React from "react";
+import PropTypes from "prop-types";
+import {
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  Button,
+} from "@mui/material";
 
 const ConfirmationPopup = ({ open, onConfirm, onCancel }) => {
   return (
-    <Dialog open={open} onClose={onCancel}>
+    <Dialog open={open} onClose={onCancel} closeAfterTransition={false}>
       <DialogTitle>Confirm Action</DialogTitle>
       <DialogContent>
-        <DialogContentText>Are you sure you want to perform this action?</DialogContentText>
+        <DialogContentText>
+          Are you sure you want to perform this action?
+        </DialogContentText>
       </DialogContent>
       <DialogActions>
         <Button onClick={onCancel}>Cancel</Button>
-        <Button onClick={onConfirm} color="primary">Confirm</Button>
+        <Button onClick={onConfirm} color="primary">
+          Confirm
+        </Button>
       </DialogActions>
     </Dialog>
   );

--- a/frontend/src/templates/GuideMainPageTemplate/GuideMainPageComponents/ConfirmationPopup/ConfirmationPopup.jsx
+++ b/frontend/src/templates/GuideMainPageTemplate/GuideMainPageComponents/ConfirmationPopup/ConfirmationPopup.jsx
@@ -11,7 +11,7 @@ import {
 
 const ConfirmationPopup = ({ open, onConfirm, onCancel }) => {
   return (
-    <Dialog open={open} onClose={onCancel} closeAfterTransition={false}>
+    <Dialog open={open} onClose={onCancel} closeAfterTransition={open}>
       <DialogTitle>Confirm Action</DialogTitle>
       <DialogContent>
         <DialogContentText>

--- a/frontend/src/templates/GuideTemplate/GuideTemplate.jsx
+++ b/frontend/src/templates/GuideTemplate/GuideTemplate.jsx
@@ -21,9 +21,10 @@ const GuideTemplate = ({
 
   return (
     <Dialog
+      closeAfterTransition={false}
       open={isOpen}
       onClose={closeDialog}
-      maxWidth='lg'
+      maxWidth="lg"
       PaperProps={{ style: { position: "static" } }}
     >
       <div className={styles.container}>
@@ -60,13 +61,13 @@ const GuideTemplate = ({
             </div>
             <div className={styles.optionButtons}>
               <Button
-                text='Cancel'
-                buttonType='secondary-grey'
+                text="Cancel"
+                buttonType="secondary-grey"
                 onClick={() => {
                   closeDialog();
                 }}
               />
-              <Button text='Save' onClick={onSave} />
+              <Button text="Save" onClick={onSave} />
             </div>
           </div>
         </div>

--- a/frontend/src/templates/GuideTemplate/GuideTemplate.jsx
+++ b/frontend/src/templates/GuideTemplate/GuideTemplate.jsx
@@ -21,7 +21,7 @@ const GuideTemplate = ({
 
   return (
     <Dialog
-      closeAfterTransition={false}
+      closeAfterTransition={isOpen}
       open={isOpen}
       onClose={closeDialog}
       maxWidth="lg"


### PR DESCRIPTION
## Describe your changes
After debugging, I found that the aria-hidden attribute was being added to the root element <div id="root"> when a Dialog opened, causing accessibility issues by hiding the focused element from assistive technologies. The issue was resolved by adding closeAfterTransition={open} to the Dialog, ensuring it remains mounted in the DOM during transitions and prevents the root element from being hidden. I also noticed the same issue occurred with the ConfirmationPopup, so I applied the same fix there to ensure consistent behavior across both components.

Briefly describe the changes you made and their purpose.

## Issue number
this PR addresses Blocked aria-hidden on an element because its descendant retained focus. #422

Mention the issue number(s) this PR addresses (e.g., #123).

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme.
- [x] My PR is granular and targeted to one specific feature.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.
